### PR TITLE
Add some failing tests

### DIFF
--- a/tripcode_test.go
+++ b/tripcode_test.go
@@ -8,7 +8,11 @@ func TestTripcode(t *testing.T) {
 	cases := map[string]string{
 		"asd":        "TAPy3blMsc",
 		"adasd":      "IOuORdzMKw",
-		"!@#$%^&*()": "96TA4mR8Fc",
+		"!@#$%^&*()": "BpZUCmJAIQ",
+		"f}E":        "oUBoOTrysY",
+		"©":          "",
+		"訛":          "c8eDXvwFLQ",
+		"'":          "8/08awL.AE",
 	}
 	for pass, expected := range cases {
 		trip := Tripcode(pass)


### PR DESCRIPTION
Hey, I noticed that this library isn't exactly implementing the tripcode algorithm correctly, so I added some failing tests to help you out.
- A corrected output for `!@#$%^&*()`. This string is longer than the allowed length for tripcode passwords (8), so it should return the same result as `!@#$%^&*`.
- A simple, but failing, test for `f}E`.
- Symbols like the copyright symbol `©` are supposed to be ignored but are not in this library
- Weird symbols like [`U+8A1B CJK UNIFIED IDEOGRAPH-8A1B`](http://codepoints.net/U+8A1B) do not yield the correct tripcode.
