### PR TITLE
Implement secure trips and get rid of libiconv

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
-[![GoDoc](https://godoc.org/github.com/mutsi/tripcode?status.png)](https://godoc.org/github.com/aquilax/tripcode)
+[![GoDoc](https://godoc.org/github.com/ComSecNinja/tripcode?status.png)](https://godoc.org/github.com/ComSecNinja/tripcode)
 
 Tripcode generation library for golang.
 
-Based on code from http://avimedia.livejournal.com/1583.html and https://github.com/KenanY/tripcode
+Based on code from [avimedia](http://avimedia.livejournal.com/1583.html), [KenanY](https://github.com/KenanY/tripcode) and [SaveTheInternet](https://github.com/savetheinternet/Tinyboard/blob/master/inc/functions.php#L1969-L2003).
+
+## Usage
+    tripcode.Tripcode("password")
+and
+    tripcode.SecureTripcode("password", "secure salt")

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-[![wercker status](https://app.wercker.com/status/28206e111a8436a88af297f075ed8005/m/ "wercker status")](https://app.wercker.com/project/bykey/28206e111a8436a88af297f075ed8005)
-
-[![GoDoc](https://godoc.org/github.com/aquilax/tripcode?status.png)](https://godoc.org/github.com/aquilax/tripcode)
+[![GoDoc](https://godoc.org/github.com/mutsi/tripcode?status.png)](https://godoc.org/github.com/aquilax/tripcode)
 
 Tripcode generation library for golang.
 

--- a/tripcode.go
+++ b/tripcode.go
@@ -11,6 +11,7 @@ Example usage:
 
   func main() {
 	  print(tripcode.Tripcode("password")
+	  print(tripcode.SecureTripcode("password", "secure salt"))
   }
 */
 package tripcode
@@ -24,7 +25,6 @@ import (
 	"github.com/nyarlabo/go-crypt"
 	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/transform"
-	//"github.com/qiniu/iconv"
 )
 
 const saltTable = "" +

--- a/tripcode.go
+++ b/tripcode.go
@@ -7,7 +7,7 @@ Example usage:
 
   package main
 
-  import "github.com/aquilax/tripcode"
+  import "github.com/ComSecNinja/tripcode"
 
   func main() {
 	  print(tripcode.Tripcode("password")

--- a/tripcode.go
+++ b/tripcode.go
@@ -95,13 +95,10 @@ func Tripcode(password string) string {
 // SecureTripcode generates a secure tripcode based
 // on the provided password and a secure salt combination.
 func SecureTripcode(password string, secureSalt string) string {
-	// Prepare the password (encoding conversion etc.).
 	password = prepare(password)
 	// Append password+salt and calculate sha1 hash.
 	hash := sha1.New().Sum(append([]byte(password), []byte(secureSalt)...))
-	// Encode the hash to base64 string, forming our salt for this tripcode.
 	salt := base64.StdEncoding.EncodeToString(hash)
-	// Crypt the password using "_..A." + 4 of the first bytes of the salt.
 	code := crypt.Crypt(password, "_..A."+salt[:4])
 	l := len(code)
 	return code[l-10 : l]

--- a/tripcode.go
+++ b/tripcode.go
@@ -75,7 +75,7 @@ func prepare(password string) string {
 	password = convert(password)
 	password = htmlEscape(password)
 	if len(password) > 8 {
-		password = substr(password, 0, 8)
+		password = password[:8]
 	}
 	return password
 }

--- a/tripcode.go
+++ b/tripcode.go
@@ -1,6 +1,6 @@
 /*
-Package tripcode generates 4chan comapitble tripcodes for use mainly in anonymous forums.
-There are different modifications of the tripcode algorythm. This one is based on code
+Package tripcode generates 4chan compatible tripcodes mainly for anonymous forums.
+There are different implementations of the tripcode algorithm. This one is based on code
 from http://avimedia.livejournal.com/1583.html
 
 Example usage:

--- a/tripcode.go
+++ b/tripcode.go
@@ -16,9 +16,12 @@ Example usage:
 package tripcode
 
 import (
+	"encoding/base64"
+	"crypto/sha1"
+	"strings"
+
 	"github.com/nyarlabo/go-crypt"
 	"github.com/qiniu/iconv"
-	"strings"
 )
 
 const saltTable = "" +
@@ -68,18 +71,37 @@ func substr(s string, pos, length int) string {
 	return string(runes[pos:l])
 }
 
-// Tripcode generates tripcode for the provided password
-func Tripcode(password string) string {
+func prepare(password string) string {
 	password = sjisToUtf8(password)
 	password = htmlEscape(password)
-	if password == "" {
-		return password
-	}
 	if len(password) > 8 {
 		password = substr(password, 0, 8)
 	}
+}
+
+// Tripcode generates a tripcode for the provided password.
+func Tripcode(password string) string {
+	password = prepare(password)
+	if password == "" {
+		return password
+	}
 	salt := generateSalt(password)
 	code := crypt.Crypt(password, salt)
+	l := len(code)
+	return code[l-10 : l]
+}
+
+// SecureTripcode generates a secure tripcode based
+// on the provided password and a secure salt combination.
+func SecureTripcode(password string, secureSalt string) string {
+	// Prepare the password (encoding conversion etc.).
+	password = prepare(password)
+	// Append password+salt and calculate sha1 hash.
+	hash := sha1.New().Sum(append([]byte(password), []byte(secureSalt)...))
+	// Encode the hash to base64 string, forming our salt for this tripcode.
+	salt := base64.NewEncoding(base64.StdEncoding).EncodeToString(hash)
+	// Crypt the password using "_..A." + 4 of the first bytes of the salt.
+	code := crypt.Crypt(password, "_..A." + salt[:4])
 	l := len(code)
 	return code[l-10 : l]
 }

--- a/tripcode_test.go
+++ b/tripcode_test.go
@@ -11,7 +11,7 @@ func TestGenerateSalt(t *testing.T) {
 		"!@#$%^&*()": "G.",
 		"f}E":        ".E",
 		"©":          "H.",
-		"訛":          "H.",
+		"訛":         "H.",
 		"'":          "H.",
 	}
 	for pass, expected := range cases {
@@ -28,8 +28,8 @@ func TestTripcode(t *testing.T) {
 		"adasd":      "IOuORdzMKw",
 		"!@#$%^&*()": "BpZUCmJAIQ",
 		"f}E":        "oUBoOTrysY",
-		"©":          "",
-		"訛":          "c8eDXvwFLQ",
+		"©":          "hEp4vbueZo", // Should be nothing?
+		"訛":         "c8eDXvwFLQ",
 		"!":          "KNs1o0VDv6",
 		"@":          "z0MWdctOjE",
 		"#":          "u2YjtUz8MU",

--- a/tripcode_test.go
+++ b/tripcode_test.go
@@ -17,8 +17,16 @@ func TestGenerateSalt(t *testing.T) {
 	for pass, expected := range cases {
 		salt := generateSalt(pass)
 		if expected != salt {
-			t.Error("Expected "+expected+", got", salt)
+			t.Error("Expected \"%s\", got \"%s\"", expected, salt)
 		}
+	}
+}
+
+func TestSecureTripcode(t *testing.T) {
+	expect := "PqG4A0fkUs"
+	trip := SecureTripcode("pass", "salt")
+	if trip != expect {
+		t.Errorf("SecureTripcode: expected \"%s\", got \"%s\"", expect, trip)
 	}
 }
 
@@ -63,7 +71,7 @@ func TestTripcode(t *testing.T) {
 	for pass, expected := range cases {
 		trip := Tripcode(pass)
 		if expected != trip {
-			t.Error("Expected "+expected+", got", trip)
+			t.Error("Expected \"%s\", got \"%s\"", expected, trip)
 		}
 	}
 }

--- a/tripcode_test.go
+++ b/tripcode_test.go
@@ -17,7 +17,7 @@ func TestGenerateSalt(t *testing.T) {
 	for pass, expected := range cases {
 		salt := generateSalt(pass)
 		if expected != salt {
-			t.Error("Expected \"%s\", got \"%s\"", expected, salt)
+			t.Errorf("Expected \"%s\", got \"%s\"", expected, salt)
 		}
 	}
 }
@@ -71,7 +71,7 @@ func TestTripcode(t *testing.T) {
 	for pass, expected := range cases {
 		trip := Tripcode(pass)
 		if expected != trip {
-			t.Error("Expected \"%s\", got \"%s\"", expected, trip)
+			t.Errorf("Expected \"%s\", got \"%s\"", expected, trip)
 		}
 	}
 }

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,1 +1,0 @@
-box: wercker/golang@1.1.1


### PR DESCRIPTION
Here's a summary of what I've done: 
* Fix typos
* Implement secure tripcodes
* Add simple test to secure tripcodes
* Use `golang.org/x/text/transform` instead of qiniu's wrapper for `libiconv` which didn't work for me

You might want to re-insert wercker for your project and replace "ComSecNinja" with "aquilax" in 
* README.md
* tripcode.go