### PR TITLE
Fix example_test case names. `go mod tidy`.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: 1.18
+        go-version: 1.23.0
 
     - name: Build
       run: go build -v ./...

--- a/example_test.go
+++ b/example_test.go
@@ -6,13 +6,13 @@ import (
 	"github.com/aquilax/tripcode"
 )
 
-func ExampleTripcode_Tripcode() {
+func ExampleTripcode() {
 	fmt.Println(tripcode.Tripcode("password"))
 	// Output:
 	// ozOtJW9BFA
 }
 
-func ExampleTripcode_SecureTripcode() {
+func ExampleSecureTripcode() {
 	fmt.Println(tripcode.SecureTripcode("password", "salt"))
 	// Output:
 	// Xtv3pggJ9U

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/aquilax/tripcode
 
-go 1.19
+go 1.23.0
+
+toolchain go1.24.1
 
 require (
 	gitlab.com/nyarla/go-crypt v0.0.0-20160106005555-d9a5dc2b789b


### PR DESCRIPTION
I went to run tests and go complained about `go mod tidy` needing to be run. So I did that and then fixed the example test cases so the tool stopped whining about em.